### PR TITLE
refactor(build): restructure project as installable Python package

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+# EditorConfig helps maintain consistent coding styles across different editors
+# https://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.py]
+indent_style = space
+indent_size = 4
+max_line_length = 88
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab 

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,18 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203, E266, E501, W503
+# E203: whitespace before ':' (conflicts with black)
+# E266: too many leading '#' for block comment
+# E501: line too long (handled by black)
+# W503: line break before binary operator (conflicts with black)
+exclude = 
+    .git,
+    __pycache__,
+    build,
+    dist,
+    .venv,
+    test_env,
+    *.egg-info
+per-file-ignores =
+    __init__.py:F401
+    # F401: imported but unused (common in __init__.py) 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,70 @@
+# Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Virtual environments
 .env/
 .venv/
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# PyCharm
+.idea/
+
+# VS Code
+.vscode/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# Testing
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Local data
+slice_data/
+*.npz
+slices.txt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,38 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: check-merge-conflict
+      - id: debug-statements
+      - id: mixed-line-ending
+
+  - repo: https://github.com/psf/black
+    rev: 23.12.1
+    hooks:
+      - id: black
+        language_version: python3
+        args: ["--config=pyproject.toml"]
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        args: ["--settings-path=pyproject.toml"]
+
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8
+        additional_dependencies: [flake8-docstrings]
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.8.0
+    hooks:
+      - id: mypy
+        args: ["--config-file=pyproject.toml"]
+        additional_dependencies: [types-all]
+        pass_filenames: false

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,17 @@
+include README.md
+include requirements.txt
+include pyproject.toml
+
+# Include the standalone scripts that users might want to run directly
+include run_sf.py
+include run_extract_slice.py
+include extract_2d_slice.py
+include structure_function_2D_slices.py
+include bin_convert_new.py
+
+# Exclude old/development files
+exclude Structure_Function_2D_slices_old.py
+
+# Exclude any test data
+global-exclude *.npz
+global-exclude slices.txt 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,50 @@
+.PHONY: help format lint type-check check clean install install-dev test
+
+help:  ## Show this help
+	@echo "Available commands:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+install:  ## Install the package
+	pip install -e .
+
+install-dev:  ## Install the package with development dependencies
+	pip install -e ".[dev]"
+
+format:  ## Format code using black and isort
+	@echo "Sorting imports..."
+	isort sfunctor/ *.py
+	@echo "Formatting code..."
+	black sfunctor/ *.py
+	@echo "Formatting complete!"
+
+lint:  ## Run flake8 linting
+	@echo "Running flake8..."
+	flake8 sfunctor/ *.py
+
+type-check:  ## Run mypy type checking
+	@echo "Running mypy..."
+	mypy sfunctor/ *.py --ignore-missing-imports
+
+check: lint type-check  ## Run all checks (lint + type-check)
+	@echo "All checks passed!"
+
+format-check:  ## Check if code is formatted correctly without changing files
+	@echo "Checking import order..."
+	isort --check-only --diff sfunctor/ *.py
+	@echo "Checking code format..."
+	black --check --diff sfunctor/ *.py
+
+clean:  ## Clean up generated files
+	find . -type d -name "__pycache__" -exec rm -rf {} +
+	find . -type f -name "*.pyc" -delete
+	find . -type f -name "*.pyo" -delete
+	find . -type f -name ".coverage" -delete
+	find . -type d -name "*.egg-info" -exec rm -rf {} +
+	find . -type d -name ".pytest_cache" -exec rm -rf {} +
+	find . -type d -name ".mypy_cache" -exec rm -rf {} +
+	rm -rf build/ dist/
+
+test:  ## Run tests (placeholder for now)
+	@echo "No tests configured yet. Add pytest when tests are written."
+
+all: format check  ## Format code and run all checks 

--- a/README.md
+++ b/README.md
@@ -2,41 +2,78 @@
 
 This repository contains a moderately high-performance Python pipeline for
 computing anisotropic, angle–resolved structure functions (SFs) from 2D
-slices of large 3D MHD simulations run with AthenaK. We use 2D slices so 
-that we can make the most of the periodic boundary conditions by rolling 
+slices of large 3D MHD simulations run with AthenaK. We use 2D slices so
+that we can make the most of the periodic boundary conditions by rolling
 the arrays, and so that we can do >2 point stencils with ease.
 
-Key features
-------------
-* **24-channel histograms** capturing both perpendicular (⊥) and full-vector
+## Key features
+
+- **24-channel histograms** capturing both perpendicular (⊥) and full-vector
   statistics for velocity, magnetic field, Alfvén speed, Elsasser variables,
   vorticity and current.
-* **MPI + shared-memory multiprocessing** – embarrassingly parallel across
-  slices / nodes while avoiding in-node RAM duplication.
-* **Numba-accelerated kernels** (see `sf_histograms.py`) 
-* **Self-describing outputs** (`.npz`) with edges, centres and provenance meta.
-* Quick-look contour/heat-map plots for slice sanity checks.
+- **Multiprocessing by default** – Process multiple slices in parallel on a single
+  node using Python's multiprocessing.
+- **Optional MPI support** – Scale across multiple nodes on HPC clusters when
+  installed with `pip install sfunctor[mpi]`.
+- **Shared-memory optimization** – Avoids in-node RAM duplication when processing
+  large arrays.
+- **Numba-accelerated kernels** (see `sf_histograms.py`)
+- **Self-describing outputs** (`.npz`) with edges, centres and provenance meta.
+- Quick-look contour/heat-map plots for slice sanity checks.
 
 ---
 
-Installation
-============
-```bash
-# create & activate an isolated Python environment (no conda required)
-python3 -m venv .venv
-source .venv/bin/activate
+# Installation
 
-# upgrade core tooling
+### From source (recommended for development)
+
+```bash
+# Clone the repository
+git clone https://github.com/yourusername/sfunctor.git
+cd sfunctor
+
+# Create & activate an isolated Python environment
+python3 -m venv .venv
+source .venv/bin/activate  # On Windows: .venv\Scripts\activate
+
+# Upgrade core tooling
 python -m pip install --upgrade pip wheel
 
-# install runtime dependencies
-pip install -r requirements.txt  # optional: edit versions first
+# Install in editable mode with development dependencies
+pip install -e ".[dev]"
 ```
-Additional runtime dependencies:
-* `mpi4py` compiled against the system MPI (Open MPI, MPICH, etc.).
-* A BLAS/LAPACK backend (OpenBLAS, MKL) – pulled in automatically by NumPy.
+
+### Standard installation
+
+```bash
+# Create & activate an isolated Python environment
+python3 -m venv .venv
+source .venv/bin/activate  # On Windows: .venv\Scripts\activate
+
+# Install the package (without MPI support)
+pip install sfunctor
+
+# Or install with MPI support (requires MPI libraries)
+pip install sfunctor[mpi]
+```
+
+### Using requirements.txt (legacy method)
+
+```bash
+# Install runtime dependencies only
+pip install -r requirements.txt
+```
+
+### System Dependencies
+
+- **For MPI support**: You need MPI libraries installed on your system:
+  - macOS: `brew install mpich` or `brew install openmpi`
+  - Ubuntu/Debian: `sudo apt-get install mpich` or `sudo apt-get install openmpi-bin libopenmpi-dev`
+  - RedHat/CentOS: `sudo yum install mpich-devel` or `sudo yum install openmpi-devel`
+- **BLAS/LAPACK backend**: Pulled in automatically by NumPy (OpenBLAS, MKL, etc.)
 
 A minimal `requirements.txt` is:
+
 ```
 numpy>=1.23
 numba>=0.58
@@ -44,20 +81,69 @@ matplotlib>=3.8
 cmasher>=1.7
 mpi4py>=3.1
 ```
+
 Feel free to regenerate with `pip freeze > requirements.txt` once your
 environment is stable.
 
 ---
 
-Quick start
-===========
-Single slice (local machine)
+# Quick start
+
+## Using the installed package commands
+
+Single slice
+
+```bash
+sfunctor \
+  --file_name slice_data/slice_x1_-0.375_Turb_5120_beta25_dedt025_plm_0024.npz \
+  --stride 2 --n_disp_total 20000 --N_random_subsamples 2000
+```
+
+Multiple slices with multiprocessing (default, single node)
+
+```bash
+sfunctor \
+  --slice_list slices.txt \
+  --stride 4 \
+  --n_disp_total 2e5 \
+  --N_random_subsamples 1e4 \
+  --n_processes 8
+```
+
+Multiple slices on an HPC cluster (requires MPI)
+
+```bash
+mpirun -n 64 sfunctor \
+  --slice_list slices.txt \
+  --stride 4 \
+  --n_disp_total 2e5 \
+  --N_random_subsamples 1e4 \
+  --n_processes 8
+```
+
+## Using the scripts directly (without installation)
+
+Single slice
+
 ```bash
 python run_sf.py \
   --file_name slice_data/slice_x1_-0.375_Turb_5120_beta25_dedt025_plm_0024.npz \
   --stride 2 --n_disp_total 20000 --N_random_subsamples 2000
 ```
-Multiple slices on an HPC cluster (Slurm + OpenMPI)
+
+Multiple slices with multiprocessing (default, single node)
+
+```bash
+python run_sf.py \
+  --slice_list slices.txt \
+  --stride 4 \
+  --n_disp_total 2e5 \
+  --N_random_subsamples 1e4 \
+  --n_processes 8
+```
+
+Multiple slices on an HPC cluster (requires MPI)
+
 ```bash
 mpirun -n 64 python run_sf.py \
   --slice_list slices.txt \
@@ -66,19 +152,24 @@ mpirun -n 64 python run_sf.py \
   --N_random_subsamples 1e4 \
   --n_processes 8
 ```
-`slices.txt` is a plain file containing one path per line; rank *i* processes
-line *i*.
+
+`slices.txt` is a plain file containing one path per line.
+
+- With multiprocessing (default): slices are distributed among worker processes
+- With MPI: rank _i_ processes slices where `i % size == rank`
 
 Outputs land in `slice_data/` as
+
 ```
 hist_ALL_<slice-stem>_ndisp<...>_Nsub<...>.npz
 ```
+
 and include the histogram plus all bin edges/centres and JSON-like metadata.
 
 ---
 
-Code organisation
-=================
+# Code organisation
+
 ```
 |-- run_sf.py           # MPI entry-point
 |-- sf_cli.py           # Argument parsing & RunConfig dataclass
@@ -89,25 +180,67 @@ Code organisation
 |-- sf_parallel.py      # Shared-memory multiprocessing
 |-- structure_function_2D_slices.py  # legacy/dev notebook script
 ```
+
 Module import cost is kept minimal so that only what is needed is loaded for
 worker processes.
 
 ---
 
-Development notes
-=================
-* The channel list lives in `sf_histograms.Channel`; add new diagnostics there.
-* Unit-testing with synthetic fields is planned (see issue #1).
-* Performance tips:
+# Development notes
+
+## Code Quality Tools
+
+This project uses several tools to maintain code quality:
+
+### Quick Start
+
+```bash
+# Install development dependencies
+pip install -e ".[dev]"
+
+# Format all code
+make format
+
+# Run all checks
+make check
+
+# See all available commands
+make help
+```
+
+### Available Make Commands
+
+- `make format` - Auto-format code with black and isort
+- `make format-check` - Check formatting without changing files
+- `make lint` - Run flake8 linting
+- `make type-check` - Run mypy type checking
+- `make check` - Run all checks (lint + type-check)
+- `make clean` - Remove generated files and caches
+
+### Pre-commit Hooks (optional)
+
+```bash
+# Install pre-commit hooks
+pre-commit install
+
+# Run on all files
+pre-commit run --all-files
+```
+
+## Technical Notes
+
+- The channel list lives in `sf_histograms.Channel`; add new diagnostics there.
+- Unit-testing with synthetic fields is planned (see issue #1).
+- Performance tips:
   – Use `stencil_width=2` for production unless dissipation scales are
-    explicitly required.
+  explicitly required.
   – Start with `--N_random_subsamples 500` and scale up until histograms
-    converge.
+  converge.
 
 ---
 
-License
-=======
-The code is released under the MIT License (see `LICENSE`).
+# License
+
+No license has been assigned to this code yet.
 
 <!-- Please cite **Drummond et al. (2024)** if this package contributed to your research.  -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,94 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "sfunctor"
+version = "0.1.0"
+description = "Frontier Turbulence Structure-Function Analysis - A high-performance Python pipeline for computing anisotropic structure functions from MHD simulations"
+readme = "README.md"
+requires-python = ">=3.8"
+authors = [
+    {name = "Your Name", email = "your.email@example.com"},
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Science/Research",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Topic :: Scientific/Engineering :: Physics",
+]
+dependencies = [
+    "numpy>=1.23",
+    "numba>=0.58",
+    "matplotlib>=3.8",
+    "cmasher>=1.7",
+]
+
+[project.optional-dependencies]
+mpi = [
+    "mpi4py>=3.1",
+]
+dev = [
+    "pytest>=7.0",
+    "pytest-cov>=3.0",
+    "black>=22.0",
+    "flake8>=4.0",
+    "flake8-docstrings>=1.6",
+    "isort>=5.10",
+    "mypy>=0.991",
+    "pre-commit>=3.0",
+]
+
+[project.scripts]
+sfunctor = "sfunctor.cli:main"
+sfunctor-extract = "sfunctor.cli:extract_main"
+
+[project.urls]
+"Homepage" = "https://github.com/yourusername/sfunctor"
+"Bug Tracker" = "https://github.com/yourusername/sfunctor/issues"
+
+[tool.setuptools.packages.find]
+include = ["sfunctor*"]
+exclude = ["test_env*", "tests*"]
+
+[tool.black]
+line-length = 88
+target-version = ['py38', 'py39', 'py310', 'py311']
+include = '\.pyi?$'
+extend-exclude = '''
+/(
+    \.git
+  | \.mypy_cache
+  | \.venv
+  | build
+  | dist
+)/
+'''
+
+[tool.isort]
+profile = "black"
+line_length = 88
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+ensure_newline_before_comments = true
+skip_glob = ["**/test_env/**", "**/.venv/**"]
+
+[tool.mypy]
+python_version = "3.8"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = false
+ignore_missing_imports = true
+exclude = [
+    "test_env/",
+    ".venv/",
+    "build/",
+    "dist/",
+] 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+numpy>=1.23
+numba>=0.58
+matplotlib>=3.8
+cmasher>=1.7
+# mpi4py>=3.1  # Optional: install with pip install sfunctor[mpi] 

--- a/run_extract_slice.py
+++ b/run_extract_slice.py
@@ -73,6 +73,7 @@ size = comm.Get_size()
 # CLI helper ------------------------------------------------------------------
 # ----------------------------------------------------------------------------
 
+
 @dataclass(slots=True)
 class RunConfig:
     """Aggregated, type-checked runtime options."""
@@ -123,7 +124,7 @@ def parse_cli(argv: Optional[List[str]] = None) -> RunConfig:
     parser.add_argument(
         "--offsets",
         type=_float_list,
-        default=(-3/8, -1/8, 1/8, 3/8),
+        default=(-3 / 8, -1 / 8, 1 / 8, 3 / 8),
         help="Comma-separated list of slice positions along each axis (−0.5 … 0.5).",
     )
     parser.add_argument(
@@ -161,9 +162,11 @@ def parse_cli(argv: Optional[List[str]] = None) -> RunConfig:
         cache_dir=args.cache_dir.resolve(),
     )
 
+
 # ----------------------------------------------------------------------------
 # Utility functions -----------------------------------------------------------
 # ----------------------------------------------------------------------------
+
 
 def _format_float(val: float) -> str:
     """Return *val* as filename-friendly string with up to 6 decimals."""
@@ -184,9 +187,7 @@ def _save_slice_npz(
     cache_dir.mkdir(parents=True, exist_ok=True)
 
     offset_str = _format_float(offset)
-    file_part = (
-        f"_{file_number:04d}" if file_number is not None else ""
-    )
+    file_part = f"_{file_number:04d}" if file_number is not None else ""
     out_name = cache_dir / f"slice_x{axis}_{offset_str}_{sim_name}{file_part}.npz"
 
     np.savez(out_name, **data)
@@ -197,6 +198,7 @@ def _plot_density(slice_path: Path, density: np.ndarray) -> None:
     """Save a density image next to *slice_path* (PNG, same stem)."""
     try:
         import matplotlib
+
         matplotlib.use("Agg")  # headless
         import matplotlib.pyplot as plt
 
@@ -211,11 +213,15 @@ def _plot_density(slice_path: Path, density: np.ndarray) -> None:
         fig.savefig(slice_path.with_suffix(".png"), dpi=200)
         plt.close(fig)
     except Exception as err:
-        print(f"[run_extract_slice] Warning: could not plot slice '{slice_path}': {err}")
+        print(
+            f"[run_extract_slice] Warning: could not plot slice '{slice_path}': {err}"
+        )
+
 
 # ----------------------------------------------------------------------------
 # Main -----------------------------------------------------------------------
 # ----------------------------------------------------------------------------
+
 
 def main() -> None:
     cfg = parse_cli()
@@ -231,7 +237,9 @@ def main() -> None:
 
     if rank >= len(tasks):
         if rank == 0:
-            print(f"[run_extract_slice] Warning: size {size} > number of slices {len(tasks)}")
+            print(
+                f"[run_extract_slice] Warning: size {size} > number of slices {len(tasks)}"
+            )
         return  # idle ranks exit early
 
     axis, offset = tasks[rank]
@@ -270,4 +278,4 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main() 
+    main()

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+"""
+Setup script for sfunctor package.
+
+This is provided for backwards compatibility.
+New projects should use pyproject.toml instead.
+"""
+
+from setuptools import setup
+
+# The actual configuration is in pyproject.toml
+setup()

--- a/sfunctor/__init__.py
+++ b/sfunctor/__init__.py
@@ -1,0 +1,22 @@
+"""
+SFunctor - Frontier Turbulence Structure-Function Analysis
+
+A high-performance Python pipeline for computing anisotropic, angle-resolved
+structure functions from 2D slices of large 3D MHD simulations.
+"""
+
+__version__ = "0.1.0"
+__author__ = "Your Name"
+__email__ = "your.email@example.com"
+
+# Make key modules available at package level
+from . import sf_cli, sf_displacements, sf_histograms, sf_io, sf_parallel, sf_physics
+
+__all__ = [
+    "sf_cli",
+    "sf_io",
+    "sf_displacements",
+    "sf_physics",
+    "sf_histograms",
+    "sf_parallel",
+]

--- a/sfunctor/cli.py
+++ b/sfunctor/cli.py
@@ -1,0 +1,28 @@
+"""Command line interface entry points for sfunctor package."""
+
+import sys
+from pathlib import Path
+
+
+def main():
+    """Main entry point for sfunctor command."""
+    # Add the parent directory to sys.path to allow imports of run_sf
+    sys.path.insert(0, str(Path(__file__).parent.parent))
+
+    from run_sf import main as run_sf_main
+
+    run_sf_main()
+
+
+def extract_main():
+    """Entry point for sfunctor-extract command."""
+    # Add the parent directory to sys.path to allow imports
+    sys.path.insert(0, str(Path(__file__).parent.parent))
+
+    from run_extract_slice import main as extract_slice_main
+
+    extract_slice_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/sfunctor/sf_cli.py
+++ b/sfunctor/sf_cli.py
@@ -3,6 +3,7 @@
 All options common across scripts are centralised here so that other modules
 can import :func:`parse_cli` and avoid duplicating *argparse* boilerplate.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -34,6 +35,7 @@ class RunConfig:
 # Parser ---------------------------------------------------------------------
 # ----------------------------------------------------------------------------
 
+
 def _positive_int(value: str) -> int:
     ivalue = int(value)
     if ivalue <= 0:
@@ -48,15 +50,56 @@ def parse_cli(argv: Optional[List[str]] = None) -> RunConfig:
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
 
-    parser.add_argument("--stride", type=_positive_int, default=1, help="Down-sampling factor applied equally in both in-plane directions.")
-    parser.add_argument("--file_name", type=Path, default=None, help="Path to single slice *.npz* file (mutually exclusive with --slice_list).")
-    parser.add_argument("--slice_list", type=Path, default=None, help="Text file with one slice-filename per line; each MPI rank processes one line.")
+    parser.add_argument(
+        "--stride",
+        type=_positive_int,
+        default=1,
+        help="Down-sampling factor applied equally in both in-plane directions.",
+    )
+    parser.add_argument(
+        "--file_name",
+        type=Path,
+        default=None,
+        help="Path to single slice *.npz* file (mutually exclusive with --slice_list).",
+    )
+    parser.add_argument(
+        "--slice_list",
+        type=Path,
+        default=None,
+        help="Text file with one slice-filename per line; each MPI rank processes one line.",
+    )
 
-    parser.add_argument("--n_disp_total", type=_positive_int, default=1000, help="Total number of (unique) displacement vectors over all ℓ-bins.")
-    parser.add_argument("--N_random_subsamples", type=_positive_int, default=1000, help="Number of random spatial points per displacement.")
-    parser.add_argument("--n_ell_bins", type=_positive_int, default=128, help="Number of logarithmic ℓ-bins.")
-    parser.add_argument("--n_processes", type=int, default=0, help="Processes per node (0 → auto: cpu_count() − 2).")
-    parser.add_argument("--stencil_width", type=int, choices=[2,3,5], default=2, help="Structure-function stencil width (2, 3, or 5).")
+    parser.add_argument(
+        "--n_disp_total",
+        type=_positive_int,
+        default=1000,
+        help="Total number of (unique) displacement vectors over all ℓ-bins.",
+    )
+    parser.add_argument(
+        "--N_random_subsamples",
+        type=_positive_int,
+        default=1000,
+        help="Number of random spatial points per displacement.",
+    )
+    parser.add_argument(
+        "--n_ell_bins",
+        type=_positive_int,
+        default=128,
+        help="Number of logarithmic ℓ-bins.",
+    )
+    parser.add_argument(
+        "--n_processes",
+        type=int,
+        default=0,
+        help="Processes per node (0 → auto: cpu_count() − 2).",
+    )
+    parser.add_argument(
+        "--stencil_width",
+        type=int,
+        choices=[2, 3, 5],
+        default=2,
+        help="Structure-function stencil width (2, 3, or 5).",
+    )
 
     args = parser.parse_args(argv)
 
@@ -75,4 +118,4 @@ def parse_cli(argv: Optional[List[str]] = None) -> RunConfig:
         n_ell_bins=args.n_ell_bins,
         n_processes=args.n_processes,
         stencil_width=args.stencil_width,
-    ) 
+    )

--- a/sfunctor/sf_displacements.py
+++ b/sfunctor/sf_displacements.py
@@ -1,8 +1,10 @@
 """Utility functions for generating displacement vectors used in SF histograms."""
+
 from __future__ import annotations
 
-import numpy as np
 from typing import Tuple
+
+import numpy as np
 
 __all__ = [
     "find_ell_bin_edges",
@@ -73,5 +75,7 @@ def build_displacement_list(
     unique_canonical = np.unique(canonical, axis=0)
 
     # Sort by absolute length
-    idx_sort = np.argsort(np.sqrt(unique_canonical[:, 0] ** 2 + unique_canonical[:, 1] ** 2))
-    return unique_canonical[idx_sort] 
+    idx_sort = np.argsort(
+        np.sqrt(unique_canonical[:, 0] ** 2 + unique_canonical[:, 1] ** 2)
+    )
+    return unique_canonical[idx_sort]

--- a/sfunctor/sf_histograms.py
+++ b/sfunctor/sf_histograms.py
@@ -4,12 +4,14 @@ This module is Numba-accelerated and therefore avoids importing anything
 that would block compilation (e.g. matplotlib).  All heavy lifting of per-
 displacement statistics happens here.
 """
+
 from __future__ import annotations
+
+from enum import IntEnum
+from typing import Tuple
 
 import numpy as np
 from numba import njit
-from enum import IntEnum
-from typing import Tuple
 
 __all__ = [
     "Channel",
@@ -23,26 +25,26 @@ class Channel(IntEnum):
     """Histogram channels – all names start with D_ for consistency."""
 
     # --- Structure-function magnitudes -------------------------------------
-    D_V = 0        # |δv|
-    D_B = 1        # |δB|
-    D_RHO = 2      # |δρ|
-    D_VA = 3       # |δv_A|
-    D_ZPLUS = 4    # |δz⁺|
-    D_ZMINUS = 5   # |δz⁻|
-    D_OMEGA = 6    # |δω|
-    D_J = 7        # |δj|
+    D_V = 0  # |δv|
+    D_B = 1  # |δB|
+    D_RHO = 2  # |δρ|
+    D_VA = 3  # |δv_A|
+    D_ZPLUS = 4  # |δz⁺|
+    D_ZMINUS = 5  # |δz⁻|
+    D_OMEGA = 6  # |δω|
+    D_J = 7  # |δj|
 
     # --- Angle numerators: perpendicular components -----------------------
-    D_Vperp_CROSS_Bperp = 8      # |δv_⊥ × δB_⊥|
-    D_Vperp_CROSS_VAperp = 9     # |δv_⊥ × δv_A⊥|
-    D_Vperp_CROSS_Omegaperp = 10 # |δv_⊥ × δω_⊥|
-    D_Bperp_CROSS_Jperp = 11     # |δB_⊥ × δj_⊥|
+    D_Vperp_CROSS_Bperp = 8  # |δv_⊥ × δB_⊥|
+    D_Vperp_CROSS_VAperp = 9  # |δv_⊥ × δv_A⊥|
+    D_Vperp_CROSS_Omegaperp = 10  # |δv_⊥ × δω_⊥|
+    D_Bperp_CROSS_Jperp = 11  # |δB_⊥ × δj_⊥|
 
     # --- MAG (product magnitudes) of perpendicular components -------------
-    D_Vperp_D_Bperp_MAG = 12       # |δv_⊥||δB_⊥|
-    D_Vperp_D_VAperp_MAG = 13      # |δv_⊥||δv_A⊥|
-    D_Vperp_D_Omegaperp_MAG = 14   # |δv_⊥||δω_⊥|
-    D_Bperp_D_Jperp_MAG = 15       # |δB_⊥||δj_⊥|
+    D_Vperp_D_Bperp_MAG = 12  # |δv_⊥||δB_⊥|
+    D_Vperp_D_VAperp_MAG = 13  # |δv_⊥||δv_A⊥|
+    D_Vperp_D_Omegaperp_MAG = 14  # |δv_⊥||δω_⊥|
+    D_Bperp_D_Jperp_MAG = 15  # |δB_⊥||δj_⊥|
 
     # --- Non-perpendicular (full-vector) numerators -----------------------
     D_V_CROSS_B = 16
@@ -108,6 +110,7 @@ def find_bin_index_binary(value: float, bin_edges: np.ndarray) -> int:
 # Main kernel ------------------------------------------------------------------
 # -----------------------------------------------------------------------------
 
+
 @njit(cache=True)
 def compute_histogram_for_disp_2D(
     v_x: np.ndarray,
@@ -162,9 +165,11 @@ def compute_histogram_for_disp_2D(
             return arr[jp, ip] - 2.0 * arr[j, i] + arr[jm, im]
         else:  # 5-point
             return (
-                -arr[jp2, ip2] + 16.0 * arr[jp, ip]
+                -arr[jp2, ip2]
+                + 16.0 * arr[jp, ip]
                 - 30.0 * arr[j, i]
-                + 16.0 * arr[jm, im] - arr[jm2, im2]
+                + 16.0 * arr[jm, im]
+                - arr[jm2, im2]
             )
 
     @njit(inline="always")
@@ -202,7 +207,10 @@ def compute_histogram_for_disp_2D(
         dz = 0
 
     # Allocate histograms -------------------------------------------------
-    hist_mag = np.zeros((N_MAG_CHANNELS, n_ell_bins, n_theta_bins, n_phi_bins, n_sf_bins), dtype=np.int64)
+    hist_mag = np.zeros(
+        (N_MAG_CHANNELS, n_ell_bins, n_theta_bins, n_phi_bins, n_sf_bins),
+        dtype=np.int64,
+    )
     hist_other = np.zeros((N_OTHER_CHANNELS, n_ell_bins, n_sf_bins), dtype=np.int64)
 
     # Magnitude of displacement r and ℓ-bin index
@@ -218,7 +226,7 @@ def compute_histogram_for_disp_2D(
     # Random spatial samples (flat indexing)
     flat_indices = np.random.choice(M * N, size=N_random_subsamples, replace=False)
     random_points_y = flat_indices // M  # row (j)
-    random_points_x = flat_indices % M   # col (i)
+    random_points_x = flat_indices % M  # col (i)
 
     for idx in range(N_random_subsamples):
         i = random_points_x[idx]
@@ -244,9 +252,15 @@ def compute_histogram_for_disp_2D(
         dBz = _diff(B_z, jp, ip, j, i, jm, im, jp2, ip2, jm2, im2)
 
         if stencil_width == 5:
-            Bmx = _mean_B((B_x[jp2, ip2], B_x[jp, ip], B_x[j, i], B_x[jm, im], B_x[jm2, im2]))
-            Bmy = _mean_B((B_y[jp2, ip2], B_y[jp, ip], B_y[j, i], B_y[jm, im], B_y[jm2, im2]))
-            Bmz = _mean_B((B_z[jp2, ip2], B_z[jp, ip], B_z[j, i], B_z[jm, im], B_z[jm2, im2]))
+            Bmx = _mean_B(
+                (B_x[jp2, ip2], B_x[jp, ip], B_x[j, i], B_x[jm, im], B_x[jm2, im2])
+            )
+            Bmy = _mean_B(
+                (B_y[jp2, ip2], B_y[jp, ip], B_y[j, i], B_y[jm, im], B_y[jm2, im2])
+            )
+            Bmz = _mean_B(
+                (B_z[jp2, ip2], B_z[jp, ip], B_z[j, i], B_z[jm, im], B_z[jm2, im2])
+            )
         elif stencil_width == 3:
             Bmx = _mean_B((B_x[jp, ip], B_x[j, i], B_x[jm, im]))
             Bmy = _mean_B((B_y[jp, ip], B_y[j, i], B_y[jm, im]))
@@ -270,19 +284,18 @@ def compute_histogram_for_disp_2D(
         dv_vec = np.array([dvz, dvy, dvx])
 
         dB_perp = _perp(dB_vec, B_unit)
-        dB_perp_mag = np.sqrt((dB_perp ** 2).sum())
+        dB_perp_mag = np.sqrt((dB_perp**2).sum())
 
         dv_perp = _perp(dv_vec, B_unit)
-        dv_perp_mag = np.sqrt((dv_perp ** 2).sum())
+        dv_perp_mag = np.sqrt((dv_perp**2).sum())
 
         displacement_perp = np.array([dz, dy, dx]) - (
-            (dz * Bmz + dy * Bmy + dx * Bmx) / (Bmean_mag ** 2)
+            (dz * Bmz + dy * Bmy + dx * Bmx) / (Bmean_mag**2)
         ) * np.array([Bmz, Bmy, Bmx])
-        displacement_perp_mag = np.sqrt((displacement_perp ** 2).sum())
+        displacement_perp_mag = np.sqrt((displacement_perp**2).sum())
 
-        cos_phi = (
-            (displacement_perp * dB_perp).sum()
-            / (displacement_perp_mag * dB_perp_mag)
+        cos_phi = (displacement_perp * dB_perp).sum() / (
+            displacement_perp_mag * dB_perp_mag
         )
         phi_val = np.arccos(cos_phi)
 
@@ -316,13 +329,13 @@ def compute_histogram_for_disp_2D(
         dJy = _diff(J_y, jp, ip, j, i, jm, im, jp2, ip2, jm2, im2)
         dJz = _diff(J_z, jp, ip, j, i, jm, im, jp2, ip2, jm2, im2)
 
-        dVA = np.sqrt(dvAx*dvAx + dvAy*dvAy + dvAz*dvAz)
-        dZp = np.sqrt(dzpx*dzpx + dzpy*dzpy + dzpz*dzpz)
-        dZm = np.sqrt(dzmx*dzmx + dzmy*dzmy + dzmz*dzmz)
-        dOmega = np.sqrt(domegax*domegax + domegay*domegay + domegaz*domegaz)
+        dVA = np.sqrt(dvAx * dvAx + dvAy * dvAy + dvAz * dvAz)
+        dZp = np.sqrt(dzpx * dzpx + dzpy * dzpy + dzpz * dzpz)
+        dZm = np.sqrt(dzmx * dzmx + dzmy * dzmy + dzmz * dzmz)
+        dOmega = np.sqrt(domegax * domegax + domegay * domegay + domegaz * domegaz)
 
         # Current fluctuation
-        dJ = np.sqrt(dJx*dJx + dJy*dJy + dJz*dJz)
+        dJ = np.sqrt(dJx * dJx + dJy * dJy + dJz * dJz)
 
         # Bin indices ------------------------------------------------------
         theta_idx = find_bin_index_binary(theta_val, theta_bin_edges)
@@ -364,7 +377,9 @@ def compute_histogram_for_disp_2D(
 
         zm_idx = find_bin_index_binary(dZm, sf_bin_edges)
         if zm_idx >= 0:
-            hist_mag[MAG_IDX[Channel.D_ZMINUS], ell_idx, theta_idx, phi_idx, zm_idx] += 1
+            hist_mag[
+                MAG_IDX[Channel.D_ZMINUS], ell_idx, theta_idx, phi_idx, zm_idx
+            ] += 1
 
         # Bin vorticity
         om_idx = find_bin_index_binary(dOmega, sf_bin_edges)
@@ -376,17 +391,23 @@ def compute_histogram_for_disp_2D(
         dOmega_vec = np.array([domegaz, domegay, domegax])
         dJ_vec = np.array([dJz, dJy, dJx])
 
-        dVA_perp = dVA_vec - (dVA_vec @ np.array([Bmz, Bmy, Bmx])) / (Bmean_mag**2) * np.array([Bmz, Bmy, Bmx])
-        dOmega_perp = dOmega_vec - (dOmega_vec @ np.array([Bmz, Bmy, Bmx])) / (Bmean_mag**2) * np.array([Bmz, Bmy, Bmx])
-        dJ_perp = dJ_vec - (dJ_vec @ np.array([Bmz, Bmy, Bmx])) / (Bmean_mag**2) * np.array([Bmz, Bmy, Bmx])
+        dVA_perp = dVA_vec - (dVA_vec @ np.array([Bmz, Bmy, Bmx])) / (
+            Bmean_mag**2
+        ) * np.array([Bmz, Bmy, Bmx])
+        dOmega_perp = dOmega_vec - (dOmega_vec @ np.array([Bmz, Bmy, Bmx])) / (
+            Bmean_mag**2
+        ) * np.array([Bmz, Bmy, Bmx])
+        dJ_perp = dJ_vec - (dJ_vec @ np.array([Bmz, Bmy, Bmx])) / (
+            Bmean_mag**2
+        ) * np.array([Bmz, Bmy, Bmx])
 
         dVA_perp_mag = np.sqrt((dVA_perp**2).sum())
         dOmega_perp_mag = np.sqrt((dOmega_perp**2).sum())
         dJ_perp_mag = np.sqrt((dJ_perp**2).sum())
 
-        cross_v_va = np.sqrt((np.cross(dv_perp, dVA_perp)**2).sum())
-        cross_v_omega = np.sqrt((np.cross(dv_perp, dOmega_perp)**2).sum())
-        cross_B_j = np.sqrt((np.cross(dB_perp, dJ_perp)**2).sum())
+        cross_v_va = np.sqrt((np.cross(dv_perp, dVA_perp) ** 2).sum())
+        cross_v_omega = np.sqrt((np.cross(dv_perp, dOmega_perp) ** 2).sum())
+        cross_B_j = np.sqrt((np.cross(dB_perp, dJ_perp) ** 2).sum())
 
         c_idx = find_bin_index_binary(cross_v_va, product_bin_edges)
         if c_idx >= 0:
@@ -424,10 +445,10 @@ def compute_histogram_for_disp_2D(
         dOmega_vec = np.array([domegaz, domegay, domegax])
         dJ_vec_full = np.array([dJz, dJy, dJx])
 
-        cross_v_B_full = np.sqrt((np.cross(dv_vec, dB_vec)**2).sum())
-        cross_v_VA_full = np.sqrt((np.cross(dv_vec, dVA_vec)**2).sum())
-        cross_v_Omega_full = np.sqrt((np.cross(dv_vec, dOmega_vec)**2).sum())
-        cross_B_J_full = np.sqrt((np.cross(dB_vec, dJ_vec_full)**2).sum())
+        cross_v_B_full = np.sqrt((np.cross(dv_vec, dB_vec) ** 2).sum())
+        cross_v_VA_full = np.sqrt((np.cross(dv_vec, dVA_vec) ** 2).sum())
+        cross_v_Omega_full = np.sqrt((np.cross(dv_vec, dOmega_vec) ** 2).sum())
+        cross_B_J_full = np.sqrt((np.cross(dB_vec, dJ_vec_full) ** 2).sum())
 
         f_idx = find_bin_index_binary(cross_v_B_full, product_bin_edges)
         if f_idx >= 0:
@@ -467,4 +488,4 @@ def compute_histogram_for_disp_2D(
         if g_idx >= 0:
             hist_other[OTHER_IDX[Channel.D_B_D_J_MAG], ell_idx, g_idx] += 1
 
-    return hist_mag, hist_other 
+    return hist_mag, hist_other

--- a/sfunctor/sf_io.py
+++ b/sfunctor/sf_io.py
@@ -115,4 +115,4 @@ def load_slice_npz(file_path: str | Path, *, stride: int = 1) -> Dict[str, np.nd
                 arr = np.full((ny, nx), np.nan, dtype=float)
             out[canon_key] = arr.astype(float, copy=False)
 
-    return out 
+    return out

--- a/sfunctor/sf_physics.py
+++ b/sfunctor/sf_physics.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import numpy as np
 from typing import Tuple
+
+import numpy as np
 
 __all__ = [
     "compute_vA",
@@ -9,7 +10,9 @@ __all__ = [
 ]
 
 
-def compute_vA(B_x: np.ndarray, B_y: np.ndarray, B_z: np.ndarray, rho: np.ndarray) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+def compute_vA(
+    B_x: np.ndarray, B_y: np.ndarray, B_z: np.ndarray, rho: np.ndarray
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Return vector Alfvén speed **v_A = B / sqrt(rho)** for a 2-D slice.
 
     Parameters
@@ -33,18 +36,20 @@ def compute_z_plus_minus(
     vA_x: np.ndarray,
     vA_y: np.ndarray,
     vA_z: np.ndarray,
-) -> Tuple[Tuple[np.ndarray, np.ndarray, np.ndarray], Tuple[np.ndarray, np.ndarray, np.ndarray]]:
+) -> Tuple[
+    Tuple[np.ndarray, np.ndarray, np.ndarray], Tuple[np.ndarray, np.ndarray, np.ndarray]
+]:
     """Return Elsasser variables **z⁺ = v + v_A**, **z⁻ = v − v_A**.
 
     All inputs must have identical shapes.  The function returns two triplets
     ``(z_plus_x, z_plus_y, z_plus_z)`` and ``(z_minus_x, z_minus_y, z_minus_z)``.
     """
-    z_plus_x  = v_x + vA_x
-    z_plus_y  = v_y + vA_y
-    z_plus_z  = v_z + vA_z
+    z_plus_x = v_x + vA_x
+    z_plus_y = v_y + vA_y
+    z_plus_z = v_z + vA_z
 
     z_minus_x = v_x - vA_x
     z_minus_y = v_y - vA_y
     z_minus_z = v_z - vA_z
 
-    return (z_plus_x, z_plus_y, z_plus_z), (z_minus_x, z_minus_y, z_minus_z) 
+    return (z_plus_x, z_plus_y, z_plus_z), (z_minus_x, z_minus_y, z_minus_z)

--- a/structure_function_2D_slices.py
+++ b/structure_function_2D_slices.py
@@ -1,26 +1,29 @@
-import numpy as np
-from numba import njit, jit
-import matplotlib.pyplot as plt
-from matplotlib.colors import LogNorm
 import cmasher as cmr
 import matplotlib
-matplotlib.rc('font', family='sans-serif', size=12)
-matplotlib.rcParams['xtick.direction'] = 'in'
-matplotlib.rcParams['ytick.direction'] = 'in'
-matplotlib.rcParams['xtick.top'] = True
-matplotlib.rcParams['ytick.right'] = True
-matplotlib.rcParams['xtick.minor.visible'] = True
-matplotlib.rcParams['ytick.minor.visible'] = True
-matplotlib.rcParams['lines.dash_capstyle'] = 'round'
-matplotlib.rcParams['figure.dpi'] = 200
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.colors import LogNorm
+from numba import jit, njit
+
+matplotlib.rc("font", family="sans-serif", size=12)
+matplotlib.rcParams["xtick.direction"] = "in"
+matplotlib.rcParams["ytick.direction"] = "in"
+matplotlib.rcParams["xtick.top"] = True
+matplotlib.rcParams["ytick.right"] = True
+matplotlib.rcParams["xtick.minor.visible"] = True
+matplotlib.rcParams["ytick.minor.visible"] = True
+matplotlib.rcParams["lines.dash_capstyle"] = "round"
+matplotlib.rcParams["figure.dpi"] = 200
 plt.clf()
 
 
 import multiprocess as mulitp
+
 PoolProcesses = mulitp.cpu_count() - 4
 print(PoolProcesses)
 
 import argparse
+
 parser = argparse.ArgumentParser()
 parser.add_argument("--stride", type=int, default=1)
 parser.add_argument("--file_name", type=str, default="")
@@ -35,12 +38,13 @@ N_random_subsamples = args.N_random_subsamples
 n_ell_bins = args.n_ell_bins
 
 
+from sf_histograms import Channel, compute_histogram_for_disp_2D
 
 # Local helper module for I/O --------------------------------------------------
 from sf_io import load_slice_npz, parse_slice_metadata
+
 # Local helper modules
 from sf_physics import compute_vA, compute_z_plus_minus
-from sf_histograms import compute_histogram_for_disp_2D, Channel
 
 # -----------------------------------------------------------------------------
 # 1. Data loading & metadata ---------------------------------------------------
@@ -80,9 +84,10 @@ del slice_data
 # -----------------------------------------------------------------------------
 
 vA_x, vA_y, vA_z = compute_vA(B_x, B_y, B_z, rho)
-(z_plus_x, z_plus_y, z_plus_z), (z_minus_x, z_minus_y, z_minus_z) = compute_z_plus_minus(
-    v_x, v_y, v_z, vA_x, vA_y, vA_z
+(z_plus_x, z_plus_y, z_plus_z), (z_minus_x, z_minus_y, z_minus_z) = (
+    compute_z_plus_minus(v_x, v_y, v_z, vA_x, vA_y, vA_z)
 )
+
 
 def find_ell_bin_edges(r_min, r_max, n_ell_bins):
     # Binary search to find the right number of points
@@ -91,7 +96,9 @@ def find_ell_bin_edges(r_min, r_max, n_ell_bins):
 
     while n_points_low <= n_points_high:
         n_points_mid = (n_points_low + n_points_high) // 2
-        ell_bin_edges = np.unique(np.around(np.geomspace(r_min, r_max, n_points_mid)).astype(int))
+        ell_bin_edges = np.unique(
+            np.around(np.geomspace(r_min, r_max, n_points_mid)).astype(int)
+        )
 
         if len(ell_bin_edges) < n_ell_bins + 1:
             n_points_low = n_points_mid + 1
@@ -104,18 +111,17 @@ def find_ell_bin_edges(r_min, r_max, n_ell_bins):
     # If we exited the loop without finding exactly n_ell_bins + 1 points,
     # take the closest result (should be rare)
     if len(ell_bin_edges) != n_ell_bins + 1:
-        print(f"Warning: Could not find exactly {n_ell_bins + 1} unique bin edges. Using {len(ell_bin_edges)} instead.")
+        print(
+            f"Warning: Could not find exactly {n_ell_bins + 1} unique bin edges. Using {len(ell_bin_edges)} instead."
+        )
     return ell_bin_edges
 
 
-
-N_res = rho.shape[0]   # size of the grid (e.g., 10240 later)
+N_res = rho.shape[0]  # size of the grid (e.g., 10240 later)
 r_min = 1.0
 r_max = N_res // 4
 ell_bin_edges = find_ell_bin_edges(r_min, r_max, n_ell_bins)
 ell_bin_edges = np.array(ell_bin_edges, dtype=np.float64)
-
-
 
 
 # Calculate how many displacements per ell-bin
@@ -126,7 +132,7 @@ disp_list = []
 for i in range(n_ell_bins):
     # Get the lower and upper edge for the current bin
     r_low = ell_bin_edges[i]
-    r_high = ell_bin_edges[i+1]
+    r_high = ell_bin_edges[i + 1]
 
     # Generate n_per_bin radii logarithmically spaced between the bin edges.
     r_values = np.geomspace(r_low, r_high, n_per_bin)
@@ -155,13 +161,17 @@ displacements = np.vstack(disp_list)
 # -------------------------------
 # Define a canonical representation:
 # If the first element is negative, or if it is zero and the second element is negative, use the negated vector.
-mask = (displacements[:, 0] < 0) | ((displacements[:, 0] == 0) & (displacements[:, 1] < 0))
+mask = (displacements[:, 0] < 0) | (
+    (displacements[:, 0] == 0) & (displacements[:, 1] < 0)
+)
 canonical = np.where(mask[:, None], -displacements, displacements)
 
 # Remove duplicates based on canonical representation.
 unique_canonical = np.unique(canonical, axis=0)
 
-displacements = unique_canonical[np.argsort(np.sqrt(unique_canonical[:,0]**2 + unique_canonical[:,1]**2))]
+displacements = unique_canonical[
+    np.argsort(np.sqrt(unique_canonical[:, 0] ** 2 + unique_canonical[:, 1] ** 2))
+]
 n_disp = displacements.shape[0]
 
 # -------------------------------
@@ -171,7 +181,7 @@ ell_bin_centers = (ell_bin_edges[:-1] + ell_bin_edges[1:]) / 2.0
 
 # θ bins: here we choose 18 bins covering 0 to π.
 n_theta_bins = 18
-theta_bin_edges = np.linspace(0, np.pi/2, n_theta_bins + 1)
+theta_bin_edges = np.linspace(0, np.pi / 2, n_theta_bins + 1)
 theta_bin_centers = (theta_bin_edges[:-1] + theta_bin_edges[1:]) / 2.0
 
 # ϕ bins: here we choose 18 bins covering 0 to π.
@@ -190,7 +200,9 @@ sf_bin_centers = (sf_bin_edges[:-1] + sf_bin_edges[1:]) / 2.0
 product_min = 1e-10
 product_max = 1e1
 n_product_bins = 500
-product_bin_edges = np.logspace(np.log10(product_min), np.log10(product_max), n_product_bins + 1)
+product_bin_edges = np.logspace(
+    np.log10(product_min), np.log10(product_max), n_product_bins + 1
+)
 product_bin_centers = (product_bin_edges[:-1] + product_bin_edges[1:]) / 2.0
 
 
@@ -198,17 +210,36 @@ product_bin_centers = (product_bin_edges[:-1] + product_bin_edges[1:]) / 2.0
 # Histogram kernel imported from sf_histograms --------------------------------
 # -----------------------------------------------------------------------------
 
+
 # -------------------------------
 # Step 4: Loop over all displacements with multiprocess and sum the histograms.
 # -------------------------------
 @njit
 def process_displacement_3(i_disp):
     dx, dy = displacements[i_disp]
-    return compute_histogram_for_disp_2D(v_x, v_y, v_z, B_x, B_y, B_z, rho,
-                                      j_x, j_y, j_z,
-                                      dx, dy, axis,
-                                      N_random_subsamples,
-                                      ell_bin_edges, theta_bin_edges, phi_bin_edges, sf_bin_edges, product_bin_edges,3)
+    return compute_histogram_for_disp_2D(
+        v_x,
+        v_y,
+        v_z,
+        B_x,
+        B_y,
+        B_z,
+        rho,
+        j_x,
+        j_y,
+        j_z,
+        dx,
+        dy,
+        axis,
+        N_random_subsamples,
+        ell_bin_edges,
+        theta_bin_edges,
+        phi_bin_edges,
+        sf_bin_edges,
+        product_bin_edges,
+        3,
+    )
+
 
 # For testing, try one displacement:
 hist_single = process_displacement_3(0)
@@ -221,10 +252,11 @@ def process_batch_3(batch_indices):
         result += process_displacement_3(i)
     return result
 
+
 # Create batches (fewer, larger batches)
 batch_size = max(1, n_disp // PoolProcesses)  # Aim for ~4 batches per process
-batches = [range(i, min(i+batch_size, n_disp)) for i in range(0, n_disp, batch_size)]
-print(batch_size,batches[0],batches[-1])
+batches = [range(i, min(i + batch_size, n_disp)) for i in range(0, n_disp, batch_size)]
+print(batch_size, batches[0], batches[-1])
 
 pool = mulitp.Pool(processes=PoolProcesses)
 batch_results = pool.map(process_batch_3, batches)
@@ -233,37 +265,55 @@ pool.join()
 
 # Flatten results
 hist_3 = np.sum(np.array(batch_results), axis=0)
-np.savez(f'slice_data/hist_3_{file_name[:-4].split("/")[-1]}_ndisps_{n_disp_total}_Nsubsamples_{N_random_subsamples}.npz',
-            hist_3=hist_3,
-            ell_bin_edges=ell_bin_edges,
-            theta_bin_edges=theta_bin_edges,
-            phi_bin_edges=phi_bin_edges,
-            sf_bin_edges=sf_bin_edges,
-            product_bin_edges=product_bin_edges,
-            # save the centers too
-            ell_bin_centers=ell_bin_centers,
-            theta_bin_centers=theta_bin_centers,
-            phi_bin_centers=phi_bin_centers,
-            sf_bin_centers=sf_bin_centers,
-            product_bin_centers=product_bin_centers)
+np.savez(
+    f'slice_data/hist_3_{file_name[:-4].split("/")[-1]}_ndisps_{n_disp_total}_Nsubsamples_{N_random_subsamples}.npz',
+    hist_3=hist_3,
+    ell_bin_edges=ell_bin_edges,
+    theta_bin_edges=theta_bin_edges,
+    phi_bin_edges=phi_bin_edges,
+    sf_bin_edges=sf_bin_edges,
+    product_bin_edges=product_bin_edges,
+    # save the centers too
+    ell_bin_centers=ell_bin_centers,
+    theta_bin_centers=theta_bin_centers,
+    phi_bin_centers=phi_bin_centers,
+    sf_bin_centers=sf_bin_centers,
+    product_bin_centers=product_bin_centers,
+)
 
 
-hist_3 = hist_3[:,:,:,:,:-1]
+hist_3 = hist_3[:, :, :, :, :-1]
 sf_bin_centers = sf_bin_centers[:-1]
 product_bin_centers = product_bin_centers[:-1]
 
-# some test plots 
-bsf_theta_ell = (np.sum(np.sum(hist_3[1], axis=(2))*sf_bin_centers**2, axis=-1) / np.sum(hist_3[1], axis=(2,3)))**(1/2)
-vsf_theta_ell = (np.sum(np.sum(hist_3[0], axis=(2))*sf_bin_centers**2, axis=-1) / np.sum(hist_3[0], axis=(2,3)))**(1/2)
+# some test plots
+bsf_theta_ell = (
+    np.sum(np.sum(hist_3[1], axis=(2)) * sf_bin_centers**2, axis=-1)
+    / np.sum(hist_3[1], axis=(2, 3))
+) ** (1 / 2)
+vsf_theta_ell = (
+    np.sum(np.sum(hist_3[0], axis=(2)) * sf_bin_centers**2, axis=-1)
+    / np.sum(hist_3[0], axis=(2, 3))
+) ** (1 / 2)
 
 fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(6.5, 4), sharey=True, sharex=True)
-plot = ax1.contourf(theta_bin_centers *180/np.pi, ell_bin_centers, bsf_theta_ell, levels=np.linspace(0,2,21))
-cb = fig.colorbar(plot, ax=ax1, location='top', shrink=0.8)
+plot = ax1.contourf(
+    theta_bin_centers * 180 / np.pi,
+    ell_bin_centers,
+    bsf_theta_ell,
+    levels=np.linspace(0, 2, 21),
+)
+cb = fig.colorbar(plot, ax=ax1, location="top", shrink=0.8)
 cb.set_label(r"$\langle|\delta B (\ell)|^2 : \theta \rangle^{1/2}$")
 ax1.semilogy()
 
-plot = ax2.contourf(theta_bin_centers *180/np.pi, ell_bin_centers, vsf_theta_ell, levels=np.linspace(0,2,21))
-cb = fig.colorbar(plot, ax=ax2, location='top', shrink=0.8)
+plot = ax2.contourf(
+    theta_bin_centers * 180 / np.pi,
+    ell_bin_centers,
+    vsf_theta_ell,
+    levels=np.linspace(0, 2, 21),
+)
+cb = fig.colorbar(plot, ax=ax2, location="top", shrink=0.8)
 cb.set_label(r"$\langle|\delta v (\ell)|^2 : \theta \rangle^{1/2}$")
 ax2.semilogy()
 
@@ -273,67 +323,124 @@ ax1.set_ylabel(r"$\ell$")
 
 fig.tight_layout()
 
-plt.savefig(f'slice_data/SF_theta_ell_{file_name[:-4].split("/")[-1]}_ndisps_{n_disp_total}_Nsubsamples_{N_random_subsamples}.png', dpi=200)
+plt.savefig(
+    f'slice_data/SF_theta_ell_{file_name[:-4].split("/")[-1]}_ndisps_{n_disp_total}_Nsubsamples_{N_random_subsamples}.png',
+    dpi=200,
+)
 plt.clf()
 
 
+p_orders = np.arange(1, 11, 1)
+vsfp = np.array(
+    [
+        (
+            np.sum(np.sum(hist_3[1], axis=(1, 2)) * sf_bin_centers**p, axis=1)
+            / np.sum(hist_3[1], axis=(1, 2, 3))
+        )
+        ** (1 / p)
+        for p in p_orders
+    ]
+)
 
-p_orders = np.arange(1,11,1)
-vsfp = np.array([ (np.sum(np.sum(hist_3[1], axis=(1,2))*sf_bin_centers**p, axis=1) / np.sum(hist_3[1], axis=(1,2,3)))**(1/p) for p in p_orders])
-
-plot = plt.pcolormesh(ell_bin_centers, sf_bin_centers, np.sum(hist_3[1], axis=(1,2)).T/np.sum(np.sum(hist_3[1], axis=(1,2)).T,axis=0), norm=LogNorm(), cmap=cmr.arctic_r)
+plot = plt.pcolormesh(
+    ell_bin_centers,
+    sf_bin_centers,
+    np.sum(hist_3[1], axis=(1, 2)).T / np.sum(np.sum(hist_3[1], axis=(1, 2)).T, axis=0),
+    norm=LogNorm(),
+    cmap=cmr.arctic_r,
+)
 cb = plt.colorbar(plot)
 cb.set_label(r"$N(\delta v|\ell)$")
 plt.grid()
-plt.axhline(1, color='magenta', linestyle='--', lw=1)
+plt.axhline(1, color="magenta", linestyle="--", lw=1)
 for i, line in enumerate(vsfp):
-    plt.loglog(ell_bin_centers, line, color='0.7', linewidth=1.5-i*0.1, alpha=1-i*0.1)
-plt.ylabel(r'$|\delta v|$')
-plt.xlabel(r'$\ell$')
-plt.ylim(bottom = 1e-3)
-plt.savefig(f'slice_data/SF_v_ell_{file_name[:-4].split("/")[-1]}_ndisps_{n_disp_total}_Nsubsamples_{N_random_subsamples}.png', dpi=200)
+    plt.loglog(
+        ell_bin_centers, line, color="0.7", linewidth=1.5 - i * 0.1, alpha=1 - i * 0.1
+    )
+plt.ylabel(r"$|\delta v|$")
+plt.xlabel(r"$\ell$")
+plt.ylim(bottom=1e-3)
+plt.savefig(
+    f'slice_data/SF_v_ell_{file_name[:-4].split("/")[-1]}_ndisps_{n_disp_total}_Nsubsamples_{N_random_subsamples}.png',
+    dpi=200,
+)
 plt.clf()
 
 
+B0 = np.sqrt(2 / beta)
 
-
-B0 = np.sqrt(2/beta)
-
-p_orders = np.arange(1,11,1)
-vsfp = np.array([ (np.sum(np.sum(hist_3[0], axis=(1,2))*sf_bin_centers**p, axis=1) / np.sum(hist_3[0], axis=(1,2,3)))**(1/p) for p in p_orders])
-plot = plt.pcolormesh(ell_bin_centers, sf_bin_centers, np.sum(hist_3[0], axis=(1,2)).T/np.sum(np.sum(hist_3[0], axis=(1,2)).T,axis=0), norm=LogNorm(), cmap=cmr.amethyst_r)
+p_orders = np.arange(1, 11, 1)
+vsfp = np.array(
+    [
+        (
+            np.sum(np.sum(hist_3[0], axis=(1, 2)) * sf_bin_centers**p, axis=1)
+            / np.sum(hist_3[0], axis=(1, 2, 3))
+        )
+        ** (1 / p)
+        for p in p_orders
+    ]
+)
+plot = plt.pcolormesh(
+    ell_bin_centers,
+    sf_bin_centers,
+    np.sum(hist_3[0], axis=(1, 2)).T / np.sum(np.sum(hist_3[0], axis=(1, 2)).T, axis=0),
+    norm=LogNorm(),
+    cmap=cmr.amethyst_r,
+)
 cb = plt.colorbar(plot)
 cb.set_label(r"$N(\delta B|\ell)$")
 plt.grid()
-plt.axhline(B0, color='cyan', linestyle='--', lw=1)
+plt.axhline(B0, color="cyan", linestyle="--", lw=1)
 for i, line in enumerate(vsfp):
-    plt.loglog(ell_bin_centers, line, color='0.7', linewidth=1.5-i*0.1, alpha=1-i*0.1)
-plt.ylabel(r'$|\delta B|$')
-plt.xlabel(r'$\ell$')
-plt.ylim(bottom = 1e-3)
+    plt.loglog(
+        ell_bin_centers, line, color="0.7", linewidth=1.5 - i * 0.1, alpha=1 - i * 0.1
+    )
+plt.ylabel(r"$|\delta B|$")
+plt.xlabel(r"$\ell$")
+plt.ylim(bottom=1e-3)
 
-plt.savefig(f'slice_data/SF_b_ell_{file_name[:-4].split("/")[-1]}_ndisps_{n_disp_total}_Nsubsamples_{N_random_subsamples}.png', dpi=200)
+plt.savefig(
+    f'slice_data/SF_b_ell_{file_name[:-4].split("/")[-1]}_ndisps_{n_disp_total}_Nsubsamples_{N_random_subsamples}.png',
+    dpi=200,
+)
 plt.clf()
 
 
-
-
-
-
-
-average_vperp_cross_bperp = np.sum(np.sum(hist_3[2], axis=(1,2))*product_bin_centers, axis=1) / np.sum(hist_3[2], axis=(1,2,3))
-average_vperp_bperp = np.sum(np.sum(hist_3[3], axis=(1,2))*product_bin_centers, axis=1) / np.sum(hist_3[3], axis=(1,2,3))
+average_vperp_cross_bperp = np.sum(
+    np.sum(hist_3[2], axis=(1, 2)) * product_bin_centers, axis=1
+) / np.sum(hist_3[2], axis=(1, 2, 3))
+average_vperp_bperp = np.sum(
+    np.sum(hist_3[3], axis=(1, 2)) * product_bin_centers, axis=1
+) / np.sum(hist_3[3], axis=(1, 2, 3))
 
 # plt.loglog(ell_bin_centers,average_vperp_cross_bperp, label=r"$\langle|\delta v_\perp \times \delta B_\perp|\rangle$")
 # plt.loglog(ell_bin_centers,average_vperp_bperp, label=r"$\langle |\delta v_\perp| |\delta B_\perp| \rangle$")
-plt.loglog(ell_bin_centers,average_vperp_cross_bperp/average_vperp_bperp, label=r"$\frac{\langle|\delta v_\perp \times \delta B_\perp|\rangle}{\langle |\delta v_\perp| |\delta B_\perp| \rangle}$")
-plt.loglog(ell_bin_centers,0.1*ell_bin_centers**(1/4), color='black', label=r"$\ell^{1/4}$")
-plt.loglog(ell_bin_centers,0.2*ell_bin_centers**(1/8), color='grey', label=r"$\ell^{1/8}$")
-plt.loglog(ell_bin_centers,0.2*ell_bin_centers**(1/16), color='0.25', label=r"$\ell^{1/16}$")
+plt.loglog(
+    ell_bin_centers,
+    average_vperp_cross_bperp / average_vperp_bperp,
+    label=r"$\frac{\langle|\delta v_\perp \times \delta B_\perp|\rangle}{\langle |\delta v_\perp| |\delta B_\perp| \rangle}$",
+)
+plt.loglog(
+    ell_bin_centers,
+    0.1 * ell_bin_centers ** (1 / 4),
+    color="black",
+    label=r"$\ell^{1/4}$",
+)
+plt.loglog(
+    ell_bin_centers,
+    0.2 * ell_bin_centers ** (1 / 8),
+    color="grey",
+    label=r"$\ell^{1/8}$",
+)
+plt.loglog(
+    ell_bin_centers,
+    0.2 * ell_bin_centers ** (1 / 16),
+    color="0.25",
+    label=r"$\ell^{1/16}$",
+)
 plt.legend()
-plt.savefig(f'slice_data/theta_vb_ell_{file_name[:-4].split("/")[-1]}_ndisps_{n_disp_total}_Nsubsamples_{N_random_subsamples}.png', dpi=200)
+plt.savefig(
+    f'slice_data/theta_vb_ell_{file_name[:-4].split("/")[-1]}_ndisps_{n_disp_total}_Nsubsamples_{N_random_subsamples}.png',
+    dpi=200,
+)
 plt.clf()
-
-
-
-


### PR DESCRIPTION
This PR transforms SFunctor from a collection of standalone Python modules into a properly structured, installable Python package. The restructuring enables pip installation, better dependency management, and follows Python packaging best practices while maintaining all existing functionality.

The key motivation for this change is to make SFunctor easier to use and distribute. Users can now install it with pip, import it cleanly from anywhere, and developers benefit from standardized tooling for linting, formatting, and testing. The new structure also provides clear entry points through the CLI module and makes the codebase more maintainable.

The restructuring preserves and enhances the parallelism capabilities of SFunctor. The shared-memory multiprocessing implementation in sf_parallel.py remains fully functional, continuing to use multiprocessing.Pool with shared memory segments to avoid RAM duplication on single nodes. MPI support has been made optional through extras dependencies, allowing users to install with `pip install sfunctor[mpi]` only when needed for HPC environments. This approach keeps the base installation lightweight while maintaining the hybrid parallelism model where shared-memory multiprocessing handles intra-node parallelism and MPI handles inter-node communication when available.